### PR TITLE
Add movie ratings support (IMDb, RT, MC) with fallback and DB schema …

### DIFF
--- a/api/movies.ts
+++ b/api/movies.ts
@@ -6,17 +6,37 @@ export default async function handler(req: Request, res: Response) {
   try {
     console.log("API /api/movies anropad");
     
-    // Använd vår executeQuery-funktion för att hämta filmer
-    const rows = await executeQuery("SELECT * FROM movies");
+    // Använder explicit kolumnlista för att säkerställa att vi får alla fält
+    const rows = await executeQuery(`
+      SELECT 
+        id, title, release_date, box_office, duration, 
+        overview, cover_url, trailer_url, directed_by, 
+        phase, saga, chronology, post_credit_scenes, 
+        imdb_id, updated_at, 
+        imdb_rating, rt_rating, mc_rating
+      FROM movies
+    `);
     
     console.log(`Hittade ${rows.length} filmer i databasen`);
     
-    // Returnera data i rätt format
+    // Loggar första filmen för att kontrollera om betygen finns med
+    if (rows.length > 0) {
+      const firstMovie = rows[0];
+      console.log("Första filmen från databasen:", {
+        id: firstMovie.id,
+        title: firstMovie.title,
+        imdb_rating: firstMovie.imdb_rating,
+        rt_rating: firstMovie.rt_rating,
+        mc_rating: firstMovie.mc_rating
+      });
+    }
+    
+    // Returnerar data i rätt format
     res.status(200).json({
       data: rows as Movie[],
       total: rows.length,
     });
-  } catch (err: any) { // 'any' för att lösa typproblemet
+  } catch (err: any) {
     console.error("Fel vid hämtning av filmer:", err);
     res.status(500).json({
       error: {

--- a/src/components/MovieCard.tsx
+++ b/src/components/MovieCard.tsx
@@ -2,15 +2,10 @@ import React from 'react';
 import { Movie, MovieCardProps } from '../types/movie';
 import '../CSS/MovieCard.css'; // Importera den dedikerade CSS-filen
 
-const MovieCard: React.FC<MovieCardProps> = ({ movie, onClick }) => { // destrukturerade propd från app.tsx
-  /** React.FC betyder att detta är en funktionell komponent i React.
-  <MovieCardProps> betyder att komponenten har specifika props, 
-  definierade av interface MovieCardProps. */
-  
+const MovieCard: React.FC<MovieCardProps> = ({ movie, onClick }) => {
   // Formatera releasedatum till läsbart format
   const formatDate = (dateString: string) => {
-    const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'long', day: 'numeric' }; 
-    // inbyggd typ i TypeScript som gör datumformatering flexibel och anpassningsbar
+    const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'long', day: 'numeric' };
     return new Date(dateString).toLocaleDateString('sv-SE', options);
   };
 
@@ -21,36 +16,46 @@ const MovieCard: React.FC<MovieCardProps> = ({ movie, onClick }) => { // destruk
     return releaseDay <= today;
   };
 
-  // Formatera betyg till decimalformat (t.ex. 7 blir 7.0)
-  const formatRating = (rating: number): string => {
-    return rating.toFixed(1);
-  };
-
   // Beräkna genomsnittsbetyg från IMDB, RT och MC
   const calculateAverageRating = (
     imdbRating: number | null | undefined, 
     rtRating: number | null | undefined, 
     mcRating: number | null | undefined
   ): number | null => {
-    // Om IMDB-betyget saknas, returnera null
-    if (!imdbRating) {
+    // Om IMDB-betyget saknas, försök använda andra betyg om de finns
+    const hasImdb = imdbRating !== null && imdbRating !== undefined;
+    const hasRt = rtRating !== null && rtRating !== undefined;
+    const hasMc = mcRating !== null && mcRating !== undefined;
+    
+    // Om inga betyg finns alls
+    if (!hasImdb && !hasRt && !hasMc) {
       return null;
     }
     
-    // Räkna ut hur många giltiga betyg vi har
-    let validRatings = 1; // IMDB finns alltid om vi kommit hit
-    let sum = imdbRating;
+    let validRatings = 0;
+    let sum = 0;
     
-    // Lägg till RT om det finns
-    if (rtRating) {
-      sum += rtRating / 10; // Konvertera till skala 0-10
+    // Lägg till IMDB om det finns
+    if (hasImdb) {
+      sum += imdbRating!;
       validRatings++;
     }
     
-    // Lägg till MC om det finns
-    if (mcRating) {
-      sum += mcRating / 10; // Konvertera till skala 0-10
+    // Lägg till RT om det finns (konvertera till skala 0-10)
+    if (hasRt) {
+      sum += rtRating! / 10;
       validRatings++;
+    }
+    
+    // Lägg till MC om det finns (konvertera till skala 0-10)
+    if (hasMc) {
+      sum += mcRating! / 10;
+      validRatings++;
+    }
+    
+    // Om inga giltiga betyg fanns
+    if (validRatings === 0) {
+      return null;
     }
 
     // Beräkna medelvärdet
@@ -59,16 +64,18 @@ const MovieCard: React.FC<MovieCardProps> = ({ movie, onClick }) => { // destruk
     // Returnera medelvärdet med en decimal precision
     return parseFloat(averageRating.toFixed(1));
   };
+  
+  // Beräkna betygsvärdet
+  const ratingValue = calculateAverageRating(
+    movie.imdb_rating, 
+    movie.rt_rating, 
+    movie.mc_rating
+  );
 
   return (
-    <article className="movie-card" onClick={() => onClick(movie)}> 
-    {/** onClick={() => onClick(movie)} → När användaren klickar på kortet:
-      Anropas onClick(movie), som är en prop från App.tsx.
-      handleMovieClick(movie) körs i App.tsx och uppdaterar selectedMovie.
-      MovieDetails.tsx visas med information om den valda filmen. */}
-
+    <article className="movie-card" onClick={() => onClick(movie)}>
       <figure className="movie-poster">
-        {movie.cover_url ? ( // Visar filmpostern om den finns
+        {movie.cover_url ? (
           <img src={movie.cover_url} alt={`Filmposter för ${movie.title}`} />
         ) : (
           <figcaption className="no-poster" aria-label="Ingen bild tillgänglig">
@@ -81,9 +88,7 @@ const MovieCard: React.FC<MovieCardProps> = ({ movie, onClick }) => { // destruk
         {/* Visa genomsnittsbetyg eller "Coming soon" beroende på om filmen har släppts */}
         {isMovieReleased(movie.release_date) ? (
           <div className="movie-rating">
-            {movie.imdb_rating && 
-              calculateAverageRating(movie.imdb_rating, movie.rt_rating || null, movie.mc_rating || null)?.toFixed(1)
-            }
+            {ratingValue !== null ? ratingValue.toFixed(1) : "N/A"}
           </div>
         ) : (
           <span className="coming-soon-card">Coming soon...</span>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,9 +1,70 @@
 import axios from 'axios';
+import { Movie } from '../types/movie';
 
 // Definiera isLocalhost
 const isLocalhost = typeof window !== 'undefined' && window.location.hostname === 'localhost';
 
-export const fetchMarvelMovies = async () => {
+// OMDb API-nyckel
+const OMDB_API_KEY = "8f57b2c1";
+
+// Hjälpfunktion för att hämta betyg från OMDb för en film
+const fetchRatingsFromOMDb = async (movie: Movie): Promise<Movie> => {
+  try {
+    // Använd filmens titel och år för sökning
+    const year = new Date(movie.release_date).getFullYear();
+    const query = encodeURIComponent(movie.title);
+    
+    console.log(`Söker efter "${movie.title}" (${year}) på OMDb...`);
+    const omdbResponse = await axios.get(`https://www.omdbapi.com/?t=${query}&y=${year}&apikey=${OMDB_API_KEY}`);
+    
+    let imdb_rating = movie.imdb_rating; // Behåll befintligt betyg om det finns
+    let rt_rating = movie.rt_rating;
+    let mc_rating = movie.mc_rating;
+    
+    if (omdbResponse.data && omdbResponse.data.Response === "True") {
+      // Hämta IMDb-betyg
+      if (omdbResponse.data.imdbRating && omdbResponse.data.imdbRating !== "N/A") {
+        imdb_rating = parseFloat(omdbResponse.data.imdbRating);
+      }
+      
+      // Hämta övriga betyg från Ratings-arrayen
+      if (omdbResponse.data.Ratings && Array.isArray(omdbResponse.data.Ratings)) {
+        for (const rating of omdbResponse.data.Ratings) {
+          if (rating.Source === "Rotten Tomatoes" && rating.Value) {
+            // Konvertera "75%" till 75
+            rt_rating = parseInt(rating.Value.replace("%", ""));
+          } else if (rating.Source === "Metacritic" && rating.Value) {
+            // Konvertera "75/100" till 75
+            mc_rating = parseInt(rating.Value.split("/")[0]);
+          }
+        }
+      }
+      
+      console.log(`Betyg för "${movie.title}": IMDb: ${imdb_rating}, RT: ${rt_rating}, MC: ${mc_rating}`);
+    } else {
+      console.log(`Ingen träff på OMDb för "${movie.title}"`);
+    }
+    
+    return {
+      ...movie,
+      imdb_rating,
+      rt_rating,
+      mc_rating
+    };
+    
+  } catch (error) {
+    console.error(`Fel vid hämtning av betyg för "${movie.title}":`, error.message);
+    return movie; // Returnera originalfilmen om något går fel
+  }
+};
+
+// Kontrollera om en film har betyg
+const hasRatings = (movie: Movie): boolean => {
+  return movie.imdb_rating !== null && 
+         movie.imdb_rating !== undefined;
+};
+
+export const fetchMarvelMovies = async (): Promise<Movie[]> => {
   try {
     if (isLocalhost) {
       // Lokalt: hämta direkt från MCU API
@@ -11,29 +72,106 @@ export const fetchMarvelMovies = async () => {
       console.log("🎬 Hämtar filmer direkt från MCU API");
       
       // För lokal utveckling - om vi vill ha dummybetyg
-      const moviesWithDummyRatings = response.data.data.map(movie => ({
+      const moviesWithDummyRatings: Movie[] = response.data.data.map((movie: Movie) => ({
         ...movie,
         imdb_rating: Math.floor(Math.random() * 20 + 65) / 10, // 6.5-8.5
         rt_rating: Math.floor(Math.random() * 20) + 75, // 75-95%
         mc_rating: Math.floor(Math.random() * 20) + 70 // 70-90
       }));
       
+      console.log("Exempel på film med betyg:", moviesWithDummyRatings[0]);
       return moviesWithDummyRatings;
     } else {
       // På Vercel: hämta från backend som hämtar från databasen
       try {
         console.log("🎬 Försöker hämta filmer från vår databas...");
         const response = await axios.get("/api/movies");
+        
+        // Logga detaljer om svaret
         console.log(`🎬 Hämtade ${response.data.data.length} filmer från backend/databas`);
+        
+        // Kontrollera om betygsfälten finns
+        const firstMovie = response.data.data[0];
+        console.log("Första filmen från databasen:", firstMovie);
+        console.log("Finns betyg i filmen?", {
+          imdb_rating: firstMovie.imdb_rating !== undefined,
+          rt_rating: firstMovie.rt_rating !== undefined,
+          mc_rating: firstMovie.mc_rating !== undefined
+        });
+        
+        // Kontrollera hur många filmer som har betyg
+        const moviesWithRatings = response.data.data.filter((m: Movie) => hasRatings(m));
+        console.log(`Filmer med betyg: ${moviesWithRatings.length} av ${response.data.data.length}`);
+        
+        // Om vi saknar betyg för vissa filmer, hämta dem från OMDb
+        if (moviesWithRatings.length < response.data.data.length) {
+          console.log("⚠️ Vissa filmer saknar betyg, försöker hämta från OMDb API...");
+          
+          // Identifiera filmer som saknar betyg
+          const moviesWithoutRatings: Movie[] = response.data.data.filter((m: Movie) => !hasRatings(m));
+          
+          // Begränsa till max 10 filmer per laddning för att spara på API-anrop
+          const filmsToUpdate = moviesWithoutRatings.slice(0, 10);
+          
+          if (filmsToUpdate.length > 0) {
+            console.log(`Hämtar betyg för ${filmsToUpdate.length} filmer från OMDb...`);
+            
+            // Hämta betyg för varje film - max 3 samtidigt för att inte överbelasta API:et
+            const enrichedMovies: Movie[] = [];
+            
+            for (let i = 0; i < filmsToUpdate.length; i++) {
+              const enrichedMovie = await fetchRatingsFromOMDb(filmsToUpdate[i]);
+              
+              // Vänta lite mellan anrop för att inte överbelasta API:et
+              await new Promise(resolve => setTimeout(resolve, 200)); 
+              
+              enrichedMovies.push(enrichedMovie);
+            }
+            
+            // Ersätt de filmer som saknade betyg med de berikade versionerna
+            const updatedMovies = response.data.data.map((movie: Movie) => {
+              const enriched = enrichedMovies.find(m => m.id === movie.id);
+              return enriched || movie;
+            });
+            
+            console.log(`🎬 Returnerar ${updatedMovies.length} filmer med betyg från både databas och OMDb`);
+            return updatedMovies;
+          }
+        }
+        
         return response.data.data;
-      } catch (err) {
+      } catch (err: any) {
         // Om databasen inte svarar, fallback till MCU API
         console.warn("⚠️ Databasfel, använder fallback till MCU API", err.message);
         const fallbackResponse = await axios.get("https://mcuapi.herokuapp.com/api/v1/movies");
-        return fallbackResponse.data.data;
+        
+        console.log("Fallback: Första filmen från MCU API:", fallbackResponse.data.data[0]);
+        console.log("⚠️ MCU API har inga betygsfält, försöker hämta från OMDb...");
+        
+        // Hämta betyg för filmer från MCU API - begränsa till första 10 för att spara API-anrop
+        const filmsToEnrich = fallbackResponse.data.data.slice(0, 10);
+        const enrichedMovies: Movie[] = [];
+        
+        for (let i = 0; i < filmsToEnrich.length; i++) {
+          const enrichedMovie = await fetchRatingsFromOMDb(filmsToEnrich[i]);
+          
+          // Vänta lite mellan anrop för att inte överbelasta API:et
+          await new Promise(resolve => setTimeout(resolve, 200)); 
+          
+          enrichedMovies.push(enrichedMovie);
+        }
+        
+        // Kombinera berikade filmer med resten av filmerna
+        const allMovies = [
+          ...enrichedMovies,
+          ...fallbackResponse.data.data.slice(10)
+        ];
+        
+        console.log(`🎬 Returnerar ${allMovies.length} filmer med betyg från fallback till OMDb`);
+        return allMovies;
       }
     }
-  } catch (error) {
+  } catch (error: any) {
     console.error("❌ Alla försök att hämta filmer misslyckades:", error);
     throw error;
   }

--- a/src/types/movie.ts
+++ b/src/types/movie.ts
@@ -1,13 +1,11 @@
 // API-svar root objekt
-export interface Root { /** Vanligt att kalla den översta nivån i en 
-  API-respons för Root, eftersom den omsluter alla data. */
+export interface Root {
   data: Movie[];
   total: number;
 }
 
 // Grundläggande filmtyp från API
 export interface Movie {
-  rating: any;
   id: number;
   title: string;
   release_date: string;
@@ -25,51 +23,26 @@ export interface Movie {
   updated_at: string;
   imdb_rating?: number | null;  // IMDb betyg (0-10)
   rt_rating?: number | null;    // Rotten Tomatoes betyg (0-100%)
-  mc_rating?: number | null;
+  mc_rating?: number | null;    // Metacritic betyg (0-100)
 }
 
-// Grundläggande props-interface
-
-// MovieCard props
+// Props-interfaces
 export interface MovieCardProps {
   movie: Movie;
   onClick: (movie: Movie) => void;
 }
 
-// MovieDetails props
 export interface MovieDetailsProps {
   movie: Movie;
   onClose: () => void;
 }
 
-// SearchFilter props
 export interface SearchFilterProps {
   searchTerm: string;
   onSearchChange: (value: string) => void;
   selectedPhase: number | null;
   onPhaseChange: (phase: number | null) => void;
   phases: number[];
-}
-
-
-export interface MovieCardProps {
-  movie: Movie; /** movie är en prop som innehåller en film som skickas från App.tsx
-                  * Movie är ett TS-if som definierar hur en film ser ut. */
-  onClick: (movie: Movie) => void; 
-}
-
-export interface MovieDetailsProps {
-  movie: Movie; // filmobjekt från app.tsx som är av typen Movie (interface)
-  onClose: () => void; /**onClose={handleCloseDetails}
-   → Skickar funktionen handleCloseDetails som prop till MovieDetails.tsx. */
-}
-
-export interface SearchFilterProps {
-  searchTerm: string; // En string som innehåller nuvarande sökterm
-  onSearchChange: (value: string) => void; // En callback-funktion som tar en string och uppdaterar söktermen.
-  selectedPhase: number | null; // Antingen ett (fas)number eller null om ingen fas är vald.
-  onPhaseChange: (phase: number | null) => void; //  En callback-funktion som tar ett number | null och uppdaterar den valda fasen.
-  phases: number[]; // En array av number, innehåller tillgängliga faser att filtrera på
   selectedRating?: number | null;
   onRatingChange?: (rating: number | null) => void;
   sortBy?: string;


### PR DESCRIPTION
…update

- Implement fallback in api.ts to fetch missing ratings from OMDb API
- Updated MovieCard.tsx to handle null ratings and avoid NaN display
- Unified Movie interface in movie.ts for consistent data structure
- Added imdb_rating, rt_rating, and mc_rating columns to PostgreSQL database via ALTER TABLE
- Confirmed saveMovies.ts successfully enriches and stores ratings in production DB